### PR TITLE
Fix hot chocolate recipe typo

### DIFF
--- a/_posts/2022-12-16-Hot-Chocolate.md
+++ b/_posts/2022-12-16-Hot-Chocolate.md
@@ -15,4 +15,4 @@ permalink: /HotChocolate/
 ## Steps
 1. Add all ingredients to pot.
 2. Heat to between 150°F and 170°F.
-3. Mix occasionally until **chocolate** and **peppermint** have disolved.
+3. Mix occasionally until **chocolate** and **peppermint** have dissolved.


### PR DESCRIPTION
## Summary
- fix misspelling of "dissolved" in hot chocolate recipe

## Testing
- `bundle exec jekyll build` *(fails: undefined method `untaint` for "Spaghetti Squash":String)*

------
https://chatgpt.com/codex/tasks/task_e_684cab0e940083269801438e37921978